### PR TITLE
API Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+### Docs ###
+build/
+cache/
+
+### PHP ###
+
 /vendor
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "illuminate/database": "~4.0",
-        "symfony/process": "~2.3"
+        "symfony/process": "~2.3",
+        "sami/sami": "2.0.*"
     },
     "suggest": {
         "zizaco/confide":"Confide is an authentication solution for Laravel 4 that couples very well with Entrust"

--- a/docs.php
+++ b/docs.php
@@ -1,0 +1,24 @@
+<?php require __DIR__ . '/vendor/autoload.php';
+
+use Sami\Sami;
+use Sami\Version\GitVersionCollection;
+use Symfony\Component\Finder\Finder;
+
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->in($dir = __DIR__ . '/src');
+
+$versions = GitVersionCollection::create($dir)
+    ->add('master', 'master branch')
+    ->addFromTags('2.*');
+
+$options = array(
+    'versions'             => $versions,
+    'title'                => 'Entrust API',
+    'build_dir'            => __DIR__ . '/build/docs/%version%',
+    'cache_dir'            => __DIR__ . '/build/cache/docs/%version%',
+    'default_opened_level' => 2,
+);
+
+return new Sami($iterator, $options);


### PR DESCRIPTION
Added a API documentation generator based on docblocks.

The example gh-page is here: http://tonglil.github.io/entrust/master/index.html, which can be created by creating a branch like this: https://github.com/tonglil/entrust/tree/gh-pages.

I find this kind of doc really helpful when I'm looking to see what the library can do for me (searching for public methods) and identify the components of a library.

Let me know if you have any issues setting it up.